### PR TITLE
Splitting up Odomplot.msg, fixing a bunch of warnings

### DIFF
--- a/include/rover_comm.hpp
+++ b/include/rover_comm.hpp
@@ -2,10 +2,11 @@
 #define ROVER_COMM_HPP
 
 #include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/joy.hpp"
-#include "geometry_msgs/msg/twist.hpp"
-#include "rover_interfaces/msg/serial.hpp"
-#include "rover_interfaces/msg/odomplot.hpp"
+#include <sensor_msgs/msg/joy.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include "rover_interfaces/msg/encoders.hpp"
 #include <cmath>
 #include <algorithm>
 
@@ -54,7 +55,8 @@ public:
     rclcpp::TimerBase::SharedPtr speak_timer_;
     rclcpp::TimerBase::SharedPtr listen_timer_;
     rclcpp::TimerBase::SharedPtr cam_move_timer_;
-    rclcpp::Publisher<rover_interfaces::msg::Odomplot>::SharedPtr odom_read_pub_; // public to be accessed from callbacks
+    rclcpp::Publisher<rover_interfaces::msg::Encoders>::SharedPtr odom_read_pub_; // public to be accessed from callbacks
+    rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_; // public to be accessed from callbacks
     std::string CaveTalk_ErrorToString(CaveTalk_Error_t error); // map to string outputs
 
     bool looping = true;
@@ -75,7 +77,6 @@ private:
     bool sendCameraMovement();
 
     // sub for /cmd_vel_joy topics and publish to joystick topic
-    rclcpp::Publisher<rover_interfaces::msg::Serial>::SharedPtr serial_read_pub_;
     rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
 
     // Params

--- a/include/rover_comms_listener.hpp
+++ b/include/rover_comms_listener.hpp
@@ -19,7 +19,6 @@ public:
     double q3_ = 0.0;
     std::chrono::time_point<std::chrono::steady_clock> prev_time_pt_ = std::chrono::steady_clock::now();
 
-
     RoverCommsListener(std::shared_ptr<RoverComm> node); //possibly need "rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr" instead
     void HearOogaBooga(const cave_talk::Say ooga_booga) override;
     void HearMovement(const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate) override;

--- a/src/rover_comm.cpp
+++ b/src/rover_comm.cpp
@@ -13,6 +13,9 @@ RoverComm::RoverComm() : Node("rover_comm")
     odom_read_pub_ = this->create_publisher<rover_interfaces::msg::Encoders>(
         "/odom_raw", 10);
 
+    imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>(
+        "/imu_data", 10);
+
     // Check for connected game controllers
     std::string type = this->gameControllerType();
 

--- a/src/rover_comm.cpp
+++ b/src/rover_comm.cpp
@@ -10,7 +10,7 @@ RoverComm::RoverComm() : Node("rover_comm")
         "/joy", 10, std::bind(&RoverComm::joyCallback, this, std::placeholders::_1));
 
     // Odom publisher
-    odom_read_pub_ = this->create_publisher<rover_interfaces::msg::Odomplot>(
+    odom_read_pub_ = this->create_publisher<rover_interfaces::msg::Encoders>(
         "/odom_raw", 10);
 
     // Check for connected game controllers

--- a/src/rover_comms_listener.cpp
+++ b/src/rover_comms_listener.cpp
@@ -82,7 +82,7 @@ void RoverCommsListener::HearConfigLog(const cave_talk::LogLevel log_level)
 
 void RoverCommsListener::HearOdometry(const cave_talk::Imu &IMU, const cave_talk::Encoder &encoder_wheel_0, const cave_talk::Encoder &encoder_wheel_1, const cave_talk::Encoder &encoder_wheel_2, const cave_talk::Encoder &encoder_wheel_3)
 {
-    auto msg = rover_interfaces::msg::Odomplot();
+    auto msg = rover_interfaces::msg::Encoders();
 
     msg.total_pulses_encoder_wheel_0 = encoder_wheel_0.total_pulses();
     msg.rate_rads_per_sec_encoder_wheel_0 = encoder_wheel_0.rate_radians_per_second();
@@ -96,12 +96,13 @@ void RoverCommsListener::HearOdometry(const cave_talk::Imu &IMU, const cave_talk
     msg.total_pulses_encoder_wheel_3 = encoder_wheel_3.total_pulses();
     msg.rate_rads_per_sec_encoder_wheel_3 = encoder_wheel_3.rate_radians_per_second();
 
-    msg.x_accel_mpss = IMU.accel().x_meters_per_second_squared(); 
-    msg.y_accel_mpss = IMU.accel().y_meters_per_second_squared();
-    msg.z_accel_mpss = IMU.accel().z_meters_per_second_squared();
-    msg.roll_rads_per_sec = IMU.gyro().roll_radians_per_second();
-    msg.pitch_rads_per_sec = IMU.gyro().pitch_radians_per_second();
-    msg.yaw_rads_per_sec = IMU.gyro().yaw_radians_per_second();
+    // Removed to publish directly to imu topic
+    // msg.x_accel_mpss = IMU.accel().x_meters_per_second_squared(); 
+    // msg.y_accel_mpss = IMU.accel().y_meters_per_second_squared();
+    // msg.z_accel_mpss = IMU.accel().z_meters_per_second_squared();
+    // msg.roll_rads_per_sec = IMU.gyro().roll_radians_per_second();
+    // msg.pitch_rads_per_sec = IMU.gyro().pitch_radians_per_second();
+    // msg.yaw_rads_per_sec = IMU.gyro().yaw_radians_per_second();
 
     rover_comm_node_->odom_read_pub_->publish(msg);
 
@@ -199,4 +200,6 @@ void RoverCommsListener::MadgwickAHRSupdateIMU(double gx, double gy, double gz,
     q3_ *= recipNorm;
 
     // MARK: EXPORT TO RTAB
+
+
 }

--- a/src/rover_comms_listener.cpp
+++ b/src/rover_comms_listener.cpp
@@ -128,6 +128,8 @@ void RoverCommsListener::HearLog(const char *const log)
 void RoverCommsListener::MadgwickAHRSupdateIMU(double gx, double gy, double gz,
     double ax, double ay, double az, std::chrono::milliseconds dt)
 {
+    auto imu_msg = sensor_msgs::msg::Imu();
+
     double beta = 0.1;
     double d;
     double recipNorm;
@@ -200,6 +202,40 @@ void RoverCommsListener::MadgwickAHRSupdateIMU(double gx, double gy, double gz,
     q3_ *= recipNorm;
 
     // MARK: EXPORT TO RTAB
+    imu_msg.header.stamp = rover_comm_node_->now();
+    imu_msg.orientation.w = q0_;
+    imu_msg.orientation.x = q1_;
+    imu_msg.orientation.y = q2_;
+    imu_msg.orientation.z = q3_;
 
+    // TODO: TUNE THIS
+    imu_msg.orientation_covariance = {
+        0.01, 0.0,  0.0,
+        0.0,  0.01, 0.0,
+        0.0,  0.0,  0.01
+    };
 
+    imu_msg.angular_velocity.x = gx;
+    imu_msg.angular_velocity.y = gy;
+    imu_msg.angular_velocity.z = gz;
+
+    // TODO: TUNE THIS
+    imu_msg.angular_velocity_covariance = {
+        0.001, 0.0,   0.0,
+        0.0,   0.001, 0.0,
+        0.0,   0.0,   0.001
+    };
+
+    imu_msg.linear_acceleration.x = ax;
+    imu_msg.linear_acceleration.y = ay;
+    imu_msg.linear_acceleration.z = az;
+
+    // TODO: TUNE THIS
+    imu_msg.linear_acceleration_covariance = {
+        0.04, 0.0,  0.0,
+        0.0,  0.04, 0.0,
+        0.0,  0.0,  0.04
+    };
+
+    rover_comm_node_->imu_pub_->publish(imu_msg)
 }

--- a/src/rover_comms_listener.cpp
+++ b/src/rover_comms_listener.cpp
@@ -38,45 +38,66 @@ void RoverCommsListener::HearOogaBooga(const cave_talk::Say ooga_booga)
 
 void RoverCommsListener::HearMovement(const CaveTalk_MetersPerSecond_t speed, const CaveTalk_RadiansPerSecond_t turn_rate)
 {
+    (void)speed;
+    (void)turn_rate;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "wagu!?");
 }
 
 void RoverCommsListener::HearCameraMovement(const CaveTalk_Radian_t pan, const CaveTalk_Radian_t tilt)
 {
+    (void)pan;
+    (void)tilt;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "maka-keega");
 }
 
 void RoverCommsListener::HearLights(const bool headlights)
 {
+    (void)headlights;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "unk!");
 }
 
 void RoverCommsListener::HearConfigEncoder(const cave_talk::ConfigEncoder &encoder_wheel_0, const cave_talk::ConfigEncoder &encoder_wheel_1, const cave_talk::ConfigEncoder &encoder_wheel_2, const cave_talk::ConfigEncoder &encoder_wheel_3)
 {
+    (void)encoder_wheel_0;
+    (void)encoder_wheel_1;
+    (void)encoder_wheel_2;
+    (void)encoder_wheel_3;
 }
 
 void RoverCommsListener::HearArm(const bool arm)
 {
+    (void)arm;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "oosha");
 }
 
 void RoverCommsListener::HearConfigServoWheels(const cave_talk::Servo &servo_wheel_0, const cave_talk::Servo &servo_wheel_1, const cave_talk::Servo &servo_wheel_2, const cave_talk::Servo &servo_wheel_3)
 {
+    (void)servo_wheel_0;
+    (void)servo_wheel_1;
+    (void)servo_wheel_2;
+    (void)servo_wheel_3;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "Hear config servowheels not impl.");
 }
 
 void RoverCommsListener::HearConfigServoCams(const cave_talk::Servo &servo_cam_pan, const cave_talk::Servo &servo_cam_tilt)
 {
+    (void)servo_cam_pan;
+    (void)servo_cam_tilt;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "Hear config servocams not impl.");
 }
 
 void RoverCommsListener::HearConfigMotor(const cave_talk::Motor &motor_wheel_0, const cave_talk::Motor &motor_wheel_1, const cave_talk::Motor &motor_wheel_2, const cave_talk::Motor &motor_wheel_3)
 {
+    (void)motor_wheel_0;
+    (void)motor_wheel_1;
+    (void)motor_wheel_2;
+    (void)motor_wheel_3;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "Hear config motor not impl.");
 }
 
 void RoverCommsListener::HearConfigLog(const cave_talk::LogLevel log_level)
 {
+    (void)log_level;
     RCLCPP_INFO(rover_comm_node_->get_logger(), "Heard log_level");
 }
 
@@ -116,8 +137,9 @@ void RoverCommsListener::HearOdometry(const cave_talk::Imu &IMU, const cave_talk
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - prev_time_pt_)
     );
 
+    std::string quat_str = "Quatw: " + std::to_string(q0_) + "Quatx: " + std::to_string(q1_) + "Quaty: " + std::to_string(q2_) + "Quatz: " + std::to_string(q3_);
     RCLCPP_INFO(rover_comm_node_->get_logger(), "Heard odom msgs");
-    RCLCPP_INFO(rover_comm_node_->get_logger(), "Quatw: ", q0_, ", Quatx: ", q1_, ", Quaty: ", q2_, ", Quatz: ", q3_);
+    RCLCPP_INFO(rover_comm_node_->get_logger(), quat_str.c_str());
 }
 
 void RoverCommsListener::HearLog(const char *const log)
@@ -131,7 +153,6 @@ void RoverCommsListener::MadgwickAHRSupdateIMU(double gx, double gy, double gz,
     auto imu_msg = sensor_msgs::msg::Imu();
 
     double beta = 0.1;
-    double d;
     double recipNorm;
     double s0, s1, s2, s3;
     double qDot1, qDot2, qDot3, qDot4;
@@ -237,5 +258,5 @@ void RoverCommsListener::MadgwickAHRSupdateIMU(double gx, double gy, double gz,
         0.0,  0.0,  0.04
     };
 
-    rover_comm_node_->imu_pub_->publish(imu_msg)
+    rover_comm_node_->imu_pub_->publish(imu_msg);
 }


### PR DESCRIPTION
I split up the Odomplot.msg into Encoders and imu. This builds, but check if any of your camera config stuff got left out.

To build this, a pull of this branch: https://github.com/CAVEMaN-SeniorDesign/Navigation_Unit_ROS2/tree/Ubuntu22, is needed to reflect the message modifications in rover_interfaces.